### PR TITLE
Non-templated idx in Cover{Counters,Bits}

### DIFF
--- a/include/coverage.hpp
+++ b/include/coverage.hpp
@@ -9,19 +9,19 @@ namespace cft {
 
 /// @brief Data structure to keep track of the number of times an element is covered by a set of
 /// sets of elements.
-template <typename IdxT>
+template <typename CounterT = uint16_t>
 struct CoverCounters {
-    using counter_t = uint16_t;
+    using counter_t = CounterT;
 
     std::vector<counter_t> cov_counters;
 
-    void reset(IdxT nelems) {
+    void reset(size_t nelems) {
         cov_counters.assign(nelems, 0);
     }
 
     template <typename IterableT>
-    IdxT cover(IterableT const& subset) {
-        IdxT covered = 0;
+    size_t cover(IterableT const& subset) {
+        size_t covered = 0;
         for (auto i : subset) {
             assert(i < cov_counters.size());
             covered += cov_counters[i] == 0 ? 1 : 0;
@@ -31,8 +31,8 @@ struct CoverCounters {
     }
 
     template <typename IterableT>
-    IdxT uncover(IterableT const& subset) {
-        IdxT uncovered = 0;
+    size_t uncover(IterableT const& subset) {
+        size_t uncovered = 0;
         for (auto i : subset) {
             assert(i < cov_counters.size());
             assert(cov_counters[i] > 0);
@@ -44,7 +44,7 @@ struct CoverCounters {
 
     template <typename IterableT>
     CFT_NODISCARD bool is_redundant(IterableT const& subset) {
-        for (IdxT i : subset)
+        for (auto i : subset)
             if (cov_counters[i] <= 1) {
                 assert(cov_counters[i] > 0);
                 return false;
@@ -52,33 +52,32 @@ struct CoverCounters {
         return true;
     }
 
-    CFT_NODISCARD counter_t operator[](IdxT i) const {
+    CFT_NODISCARD counter_t operator[](size_t i) const {
         assert(i < cov_counters.size());
         return cov_counters[i];
     }
 
-    CFT_NODISCARD IdxT size() const {
+    CFT_NODISCARD size_t size() const {
         return cov_counters.size();
     }
 };
 
-template <typename IdxT>
-CFT_NODISCARD inline CoverCounters<IdxT> make_cover_counters(IdxT nelems) {
-    return {std::vector<uint16_t>(nelems)};
+template <typename CounterT = uint16_t>
+CFT_NODISCARD inline CoverCounters<CounterT> make_cover_counters(size_t nelems) {
+    return {std::vector<CounterT>(nelems)};
 }
 
 /// @brief Data structure to keep track of what elements are covered by a set of sets of elements.
-template <typename IdxT>
 struct CoverBits {
     std::vector<bool> cov_flags;
 
-    void reset(IdxT nelems) {
+    void reset(size_t nelems) {
         cov_flags.assign(nelems, false);
     }
 
     template <typename IterableT>
-    IdxT cover(IterableT const& subset) {
-        IdxT covered = 0;
+    size_t cover(IterableT const& subset) {
+        size_t covered = 0;
         for (auto i : subset) {
             assert(i < cov_flags.size());
             bool was_covered = cov_flags[i];
@@ -89,8 +88,8 @@ struct CoverBits {
     }
 
     template <typename IterableT>
-    IdxT uncover(IterableT const& subset) {
-        IdxT uncovered = 0;
+    size_t uncover(IterableT const& subset) {
+        size_t uncovered = 0;
         for (auto i : subset) {
             assert(i < cov_flags.size());
             bool was_covered = cov_flags[i];
@@ -100,18 +99,17 @@ struct CoverBits {
         return uncovered;
     }
 
-    CFT_NODISCARD bool operator[](IdxT i) const {
+    CFT_NODISCARD bool operator[](size_t i) const {
         assert(i < cov_flags.size());
         return cov_flags[i];
     }
 
-    CFT_NODISCARD IdxT size() const {
+    CFT_NODISCARD size_t size() const {
         return cov_flags.size();
     }
 };
 
-template <typename IdxT>
-CFT_NODISCARD inline CoverBits<IdxT> make_cover_bits(IdxT nelems) {
+CFT_NODISCARD inline CoverBits make_cover_bits(size_t nelems) {
     return {std::vector<bool>(nelems)};
 }
 


### PR DESCRIPTION
I gave another thought on what you were saying about the usage of "size_t" instead of IdxT in coverage data structures. 
On second thought, I think you were right. I missed the fact the IdxT was not "structural" for these types, only something used for jit counting and returining a value, which make the use of a common IdxT totally cosmetic.
At the same time, the type of the internal counter in CoverCounters is instead "structural" and therfore that fits better as a template param, what do you think?