### PR TITLE
Found the remaining implicit casts and got rid of them (thanks to `TaggedScalar`)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 FetchContent_Declare(fmt GIT_REPOSITORY https://github.com/fmtlib/fmt)
 FetchContent_MakeAvailable(fmt)
 
-set(WARNING_FLAGS "-Wall -Wextra -Wpedantic -Wuninitialized -Wshadow -Wnull-dereference -Wduplicated-cond -Wuseless-cast -Wduplicated-branches -Winit-self -Wlogical-op -Wunused-macros -Wwrite-strings -Wextra-semi")
+set(WARNING_FLAGS "-Wall -Wextra -Wpedantic -Wuninitialized -Wshadow -Wnull-dereference -Winit-self -Wunused-macros -Wwrite-strings -Wextra-semi")
 
 set(SANITIZERS_FLAGS "-fno-omit-frame-pointer -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined")
 set(OPT_FLAGS "-O3 -flto=auto -fno-omit-frame-pointer -g")
@@ -48,26 +48,32 @@ if (UNIT_TESTS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -DCFT_ASSERT_FAIL_THROWS")
     set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS} -DCFT_ASSERT_FAIL_THROWS" )
 
-    set(SOURCES test/main.cpp
-                test/cft_unittests.cpp
-                test/Chrono_unittests.cpp
-                test/CliArgs_unittests.cpp
-                test/coverage_unittests.cpp
-                test/Instance_unittests.cpp
-                test/parse_utils_unittests.cpp
-                test/parsing_unittests.cpp
-                test/random_unittests.cpp
-                test/redundancy_unittests.cpp
-                test/Refinement_unittests.cpp
-                test/sort_unittests.cpp
-                test/SortedArray_unittests.cpp
-                test/Span_unittests.cpp
-                test/StringView_unittests.cpp
-                test/utility_unittests.cpp)
+    function(add_cft_test name)
+        set(sources test/${name}.cpp)
+        add_executable(${name} ${sources})
+        target_link_libraries(${name} PUBLIC ${LIBRARIES})
+        add_test(NAME ${name} COMMAND ${name})
+    endfunction()
 
-    add_executable(tests ${SOURCES})
-    target_link_libraries(tests PUBLIC ${LIBRARIES})
-    add_test(NAME tests COMMAND tests)
+    add_cft_test(cft_unittests)
+    add_cft_test(Chrono_unittests)
+    add_cft_test(CliArgs_unittests)
+    add_cft_test(coverage_unittests)
+    add_cft_test(custom_types_unittests)
+    add_cft_test(Instance_unittests)
+    add_cft_test(large_types_unittests)
+    add_cft_test(parse_utils_unittests)
+    add_cft_test(parsing_unittests)
+    add_cft_test(random_unittests)
+    add_cft_test(redundancy_unittests)
+    add_cft_test(Refinement_unittests)
+    add_cft_test(SortedArray_unittests)
+    add_cft_test(small_types_unittests)
+    add_cft_test(sort_unittests)
+    add_cft_test(Span_unittests)
+    add_cft_test(StringView_unittests)
+    add_cft_test(utility_unittests)
+
     enable_testing()
 
 endif() 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Along with the classic entities proper of the C programming language, we **defin
 
 Other rules:
 
+- Limit implicit casts as much as reasonably possible.
 - No storage of references or pointers within either _structs_ or _functors_, clearly they can be stored by other abstractions defined in _library code_.
 - No direct storage of resources that require special handling (e.g., pointers to allocated memory or file handles).
 - No `const` member variables.
@@ -118,3 +119,15 @@ Looking around you might notice that most function parameters are annotated with
 - **`inout`**: Input/output parameter. Both previous and new states are relevant.
 - **`cache`**: Cache object to avoid costly operations (usually memory allocations). Input and output states are ignored.
 
+### Custom Types
+
+This project offers flexibility in choosing the numeric types used for column indexes, row indexes, and real values. We provide aliases (`cidx_t`, `ridx_t`, `real_t`) defined in [`src/core/cft.hpp`](src/core/cft.hpp) that you can customize by defining the corresponding macros (`CFT_CIDX_TYPE`, `CFT_RIDX_TYPE`, `CFT_REAL_TYPE`). This allows you to easily switch between native integer/floating-point types depending on your needs.
+
+Beyond basic types, we also support defining custom types through a simple interface. You can find an example implementation in [`test/custom_types_unittests.cpp`](test/custom_type_unittests.cpp). 
+For instance, you can use this interface to:
+
+- Enforce Checks: Implement custom checks for every mathematical operation performed on your data.
+- Control Type Conversions: Restrict implicit casts, e.g., to avoid mixing row and column variables.
+- Introduce Specialized Types: Utilize alternative number representations like fixed-point types for specific use cases.
+
+This approach tries to strike a good a balance between ease of use for common numeric types and the ability to tailor the library to your specific requirements.

--- a/src/algorithms/Refinement.hpp
+++ b/src/algorithms/Refinement.hpp
@@ -26,7 +26,6 @@ namespace local { namespace {
     }
 
     class RefinementFixManager {
-        static constexpr real_t min_fixing = 0.3_F;
 
         real_t                   fix_fraction = 0.0_F;
         real_t                   prev_cost    = limits<real_t>::max();
@@ -45,7 +44,7 @@ namespace local { namespace {
 
             fix_fraction = min(1.0_F, fix_fraction * env.alpha);
             if (best_sol.cost < prev_cost)
-                fix_fraction = min_fixing;
+                fix_fraction = env.min_fixing;
             prev_cost = best_sol.cost;
 
             auto nrows_real   = as_real(rsize(inst.rows));
@@ -97,7 +96,8 @@ inline Solution run(Environment const& env,                // in
     ridx_t const nrows = rsize(orig_inst.rows);
 
     auto inst     = orig_inst;
-    auto best_sol = Solution{{}, limits<real_t>::max()};
+    auto best_sol = Solution();
+    best_sol.cost = limits<real_t>::max();
 
     if (!warmstart_sol.idxs.empty())
         best_sol = warmstart_sol;

--- a/src/algorithms/ThreePhase.hpp
+++ b/src/algorithms/ThreePhase.hpp
@@ -155,7 +155,7 @@ private:
     ) {
         for (real_t& u : lagr_mult) {
             u *= rnd_real(rnd, 0.9_F, 1.1_F);
-            assert(std::isfinite(u) && "Multiplier is not finite");
+            assert(std::isfinite(native_cast(u)) && "Multiplier is not finite");
         }
     }
 

--- a/src/core/Instance.hpp
+++ b/src/core/Instance.hpp
@@ -69,7 +69,7 @@ inline void check_inst_solution(Instance const& inst, Solution const& sol) {
     real_t total_cost = 0.0_F;
     for (cidx_t j : sol.idxs)
         total_cost += inst.costs[j];
-    assert(-1e-6_F < total_cost - sol.cost && total_cost - sol.cost < 1e-6_F);
+    assert(abs(total_cost - sol.cost) < 1e-6_F);
 }
 #endif
 
@@ -81,13 +81,12 @@ inline void fill_rows_from_cols(SparseBinMat<ridx_t> const&       cols,   // in
     rows.resize(nrows);
     for (auto& row : rows) {
         row.clear();
-        row.reserve(csize(cols.idxs) / nrows);
+        row.reserve(csize(cols.idxs) / as_cidx(nrows));
     }
 
     for (cidx_t j = 0_C; j < csize(cols); ++j)
         for (ridx_t i : cols[j])
             rows[i].push_back(j);
-    // CFT_IF_DEBUG(col_and_rows_check(cols, rows));
 }
 
 // Copy a column from one instance to another pushing it back as last column.

--- a/src/core/cft.hpp
+++ b/src/core/cft.hpp
@@ -4,13 +4,13 @@
 #ifndef CFT_SRC_CORE_CFT_HPP
 #define CFT_SRC_CORE_CFT_HPP
 
-
 #include <cstdint>
 #include <string>
 #include <vector>
 
 #include "utils/Chrono.hpp"
 #include "utils/assert.hpp"  // IWYU pragma:  keep
+#include "utils/custom_types.hpp"
 #include "utils/limits.hpp"
 #include "utils/random.hpp"
 #include "utils/utility.hpp"
@@ -27,12 +27,28 @@
 #define CFT_CVRP_PARSER "CVRP"
 #define CFT_MPS_PARSER  "MPS"
 
+#ifndef CFT_CIDX_TYPE
+#define CFT_CIDX_TYPE int32_t
+#endif
+
+#ifndef CFT_RIDX_TYPE
+#define CFT_RIDX_TYPE int16_t
+#endif
+
+#ifndef CFT_REAL_TYPE
+#define CFT_REAL_TYPE float
+#endif
+
 namespace cft {
 
-using cidx_t = int32_t;                    // Type for column indexes
-using ridx_t = int16_t;                    // Type for row indexes
-using real_t = float;                      // Type for real values
+using cidx_t = CFT_CIDX_TYPE;              // Type for column indexes
+using ridx_t = CFT_RIDX_TYPE;              // Type for row indexes
+using real_t = CFT_REAL_TYPE;              // Type for real values
 using prng_t = prng_picker<real_t>::type;  // default pseudo-random number generator type
+
+static_assert(std::is_integral<native_t<cidx_t>>::value, "cidx_t must be integral");
+static_assert(std::is_integral<native_t<ridx_t>>::value, "ridx_t must be integral");
+static_assert(std::is_floating_point<native_t<real_t>>::value, "real_t must be a floating point");
 
 // Reserved values to mark removed indexes (tombstones)
 constexpr cidx_t removed_cidx = limits<cidx_t>::max();
@@ -119,6 +135,7 @@ struct Environment {
     mutable prng_t rnd = prng_t(0);  // Random number generator
 
 
+    real_t min_fixing = 0.3_F;
     // Other hyperparameters that we might consider in the future
     // uint64_t    subgrad_exit_period      = 300;
     // double      fix_thresh               = -0.001;

--- a/src/core/parsing.hpp
+++ b/src/core/parsing.hpp
@@ -59,7 +59,7 @@ inline Instance parse_scp_instance(std::string const& path) {
             assert(0_C < cidx && cidx <= ncols);
             if (cidx <= 0_C || ncols < cidx)
                 throw std::invalid_argument("Invalid column index: not a SCP instance?");
-            cols[cidx - 1].push_back(i);
+            cols[cidx - 1_C].push_back(i);
         }
     }
 

--- a/src/fixing/ColFixing.hpp
+++ b/src/fixing/ColFixing.hpp
@@ -42,7 +42,7 @@ public:
         _select_non_overlapping_cols(inst, lagr_mult, row_coverage, cols_to_fix, reduced_costs);
         cidx_t no_overlap_ncols = csize(cols_to_fix);
 
-        cidx_t fix_at_least = csize(cols_to_fix) + max<cidx_t>(1_C, orig_nrows / 200);
+        cidx_t fix_at_least = csize(cols_to_fix) + max(1_C, as_cidx(orig_nrows / 200_R));
         greedy(inst, lagr_mult, reduced_costs, cols_to_fix, limits<real_t>::max(), fix_at_least);
 
         fix_columns_and_compute_maps(cols_to_fix, inst, fixing, old2new);

--- a/src/fixing/fix_columns.hpp
+++ b/src/fixing/fix_columns.hpp
@@ -115,7 +115,7 @@ namespace local { namespace {
         }
         cidx_t new_ncols          = new_j;
         inst.cols.begs[new_ncols] = n;
-        inst.cols.begs.resize(new_ncols + 1);
+        inst.cols.begs.resize(new_ncols + 1_C);
         inst.cols.idxs.resize(n);
         inst.costs.resize(new_ncols);
     }

--- a/src/greedy/redundancy.hpp
+++ b/src/greedy/redundancy.hpp
@@ -13,7 +13,7 @@
 #include "utils/utility.hpp"
 
 
-#define CFT_ENUM_VARS 10
+#define CFT_ENUM_VARS 10_C
 
 namespace cft {
 // Data structure to store the redundancy set and related information

--- a/src/greedy/scores.hpp
+++ b/src/greedy/scores.hpp
@@ -58,7 +58,7 @@ namespace local { namespace {
         auto& scores = score_info.scores;  // shorthand
 
         for (cidx_t j : row) {
-            score_info.covered_rows[j] -= 1;
+            score_info.covered_rows[j] -= 1_R;
             score_info.gammas[j] += i_lagr_mult;
 
             cidx_t s = score_info.score_map[j];
@@ -130,11 +130,11 @@ inline void update_changed_scores(Instance const&            inst,          // i
 inline score_subspan_t select_good_scores(Scores& score_info,  // in
                                           cidx_t  how_many     // in
 ) {
-    assert(how_many > 0 && "Good size must be greater than 0");
+    assert(how_many > 0_C && "Good size must be greater than 0");
     auto& scores = score_info.scores;  // shorthand
 
     how_many = std::min(how_many, csize(scores));
-    cft::nth_element(scores, how_many - 1, ScoreKey{});
+    cft::nth_element(scores, how_many - 1_C, ScoreKey{});
     for (cidx_t s = 0_C; s < csize(scores); ++s)
         score_info.score_map[scores[s].idx] = s;
 

--- a/src/subgradient/Pricer.hpp
+++ b/src/subgradient/Pricer.hpp
@@ -30,7 +30,7 @@ public:
         cidx_t const ncols = csize(inst.cols);
 
         assert(nrows == rsize(lagr_mult));
-        if (nrows == 0 || ncols == 0)
+        if (nrows == 0_R || ncols == 0_C)
             return 0.0_F;
 
         core.col_map.clear();
@@ -78,9 +78,9 @@ private:
             if (reduced_costs[j] < 0.1_F)
                 idxs.push_back(j);
 
-        cidx_t const maxsize = as_cidx(5 * rsize(inst.rows));
+        cidx_t const maxsize = as_cidx(5_R * rsize(inst.rows));
         if (csize(idxs) > maxsize) {
-            cft::nth_element(idxs, maxsize - 1, [&](cidx_t i) { return reduced_costs[i]; });
+            cft::nth_element(idxs, maxsize - 1_C, [&](cidx_t i) { return reduced_costs[i]; });
             idxs.resize(maxsize);
         }
 

--- a/src/subgradient/Subgradient.hpp
+++ b/src/subgradient/Subgradient.hpp
@@ -40,17 +40,17 @@ public:
                       real_t&              step_size,      // inout
                       std::vector<real_t>& best_lagr_mult  // inout
     ) {
-        ridx_t const nrows       = rsize(orig_inst.rows);
+        size_t const nrows       = size(orig_inst.rows);
         real_t const max_real_lb = cutoff - env.epsilon;
 
         assert(!orig_inst.cols.empty() && "Empty instance");
         assert(!core.inst.cols.empty() && "Empty core instance");
-        assert(nrows == rsize(core.inst.rows) && "Incompatible instances");
+        assert(nrows == size(core.inst.rows) && "Incompatible instances");
 
         auto   timer          = Chrono<>();
         auto   next_step_size = local::StepSizeManager(20, step_size);
         auto   should_exit    = local::ExitConditionManager(300);
-        auto   should_price   = local::PricingManager(10, std::min<size_t>(1000, nrows / 3));
+        auto   should_price   = local::PricingManager(10ULL, min(1000ULL, nrows / 3ULL));
         real_t best_core_lb   = limits<real_t>::min();
         auto   best_real_lb   = limits<real_t>::min();
         _reset_red_costs_and_lb(core.inst.costs, lb_sol, reduced_costs, best_core_lb);

--- a/src/utils/custom_types.hpp
+++ b/src/utils/custom_types.hpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#ifndef CFT_SRC_UTILS_MP_HPP
+#define CFT_SRC_UTILS_MP_HPP
+
+#include <type_traits>
+#include <utility>
+
+namespace cft {
+// Remove const, volatile and reference from a type
+template <typename T>
+using no_cvr = typename std::remove_reference<typename std::remove_cv<T>::type>::type;
+
+// Hook for user defined types, specialize this to get the base type.
+template <typename T>
+struct native {
+    using type = no_cvr<T>;
+};
+
+template <typename T>
+using native_t = typename native<no_cvr<T>>::type;
+
+template <typename T>
+constexpr native_t<T> native_cast(T&& t) {
+    return std::forward<T>(t);
+}
+
+
+}  // namespace cft
+
+
+#endif /* CFT_SRC_UTILS_MP_HPP */

--- a/src/utils/limits.hpp
+++ b/src/utils/limits.hpp
@@ -4,8 +4,9 @@
 #ifndef CFT_SRC_CORE_LIMITS_HPP
 #define CFT_SRC_CORE_LIMITS_HPP
 
-
 #include <limits>
+
+#include "utils/custom_types.hpp"
 
 namespace cft {
 
@@ -14,15 +15,15 @@ namespace cft {
 template <typename T>
 struct limits {
     static constexpr T max() {
-        return std::numeric_limits<T>::max();
+        return T{std::numeric_limits<native_t<T>>::max()};
     }
 
     static constexpr T min() {
-        return std::numeric_limits<T>::lowest();
+        return T{std::numeric_limits<native_t<T>>::lowest()};
     }
 
     static constexpr T inf() {
-        return std::numeric_limits<T>::infinity();
+        return T{std::numeric_limits<native_t<T>>::infinity()};
     }
 };
 

--- a/src/utils/print.hpp
+++ b/src/utils/print.hpp
@@ -8,6 +8,23 @@
 #include <fmt/ranges.h>
 
 #include "core/cft.hpp"
+#include "utils/custom_types.hpp"
+
+// Custom formatter for any type that defines a native type
+namespace fmt {
+template <typename T>
+struct formatter<T, char, typename std::enable_if<!std::is_same<T, cft::native_t<T>>::value>::type>
+    : fmt::formatter<cft::native_t<T>> {
+    using nat_t       = cft::native_t<T>;
+    using base        = fmt::formatter<nat_t>;
+    using tagged_type = T;
+
+    auto format(tagged_type c, format_context& ctx) const noexcept
+        -> decltype(base::format(static_cast<nat_t>(c), ctx)) {
+        return base::format(static_cast<nat_t>(c), ctx);
+    }
+};
+}  // namespace fmt
 
 namespace cft {
 

--- a/test/Chrono_unittests.cpp
+++ b/test/Chrono_unittests.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
 // SPDX-License-Identifier: MIT
 
+#define CATCH_CONFIG_MAIN 
 #include <catch2/catch.hpp>
 #include <thread>
 

--- a/test/CliArgs_unittests.cpp
+++ b/test/CliArgs_unittests.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
 // SPDX-License-Identifier: MIT
 
+#define CATCH_CONFIG_MAIN 
 #include <catch2/catch.hpp>
 #include <stdexcept>
 

--- a/test/Instance_unittests.cpp
+++ b/test/Instance_unittests.cpp
@@ -1,31 +1,33 @@
 // SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
 // SPDX-License-Identifier: MIT
 
+#define CATCH_CONFIG_MAIN 
 #include <catch2/catch.hpp>
 #include <stdexcept>
 
 #include "core/Instance.hpp"
+#include "core/cft.hpp"
 
 namespace cft {
 
 namespace local { namespace {
     Instance make_partial_inst() {
-        ridx_t nrows = 40;
+        ridx_t nrows = 40_R;
 
         auto cols = SparseBinMat<ridx_t>();
-        cols.push_back({1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
-        cols.push_back({11, 12, 13, 14, 15, 16, 17, 18, 19, 20});
-        cols.push_back({21, 22, 23, 24, 25, 26, 27, 28, 29, 30});
-        cols.push_back({31, 32, 33, 34, 35, 36, 37, 38, 39, 0});
-        cols.push_back({1, 11, 21, 31, 2, 12, 22, 32});
-        cols.push_back({3, 13, 23, 33, 4, 14, 24, 34});
-        cols.push_back({5, 15, 25, 35, 6, 16, 26, 36});
+        cols.push_back({1_R, 2_R, 3_R, 4_R, 5_R, 6_R, 7_R, 8_R, 9_R, 10_R});
+        cols.push_back({11_R, 12_R, 13_R, 14_R, 15_R, 16_R, 17_R, 18_R, 19_R, 20_R});
+        cols.push_back({21_R, 22_R, 23_R, 24_R, 25_R, 26_R, 27_R, 28_R, 29_R, 30_R});
+        cols.push_back({31_R, 32_R, 33_R, 34_R, 35_R, 36_R, 37_R, 38_R, 39_R, 0_R});
+        cols.push_back({1_R, 11_R, 21_R, 31_R, 2_R, 12_R, 22_R, 32_R});
+        cols.push_back({3_R, 13_R, 23_R, 33_R, 4_R, 14_R, 24_R, 34_R});
+        cols.push_back({5_R, 15_R, 25_R, 35_R, 6_R, 16_R, 26_R, 36_R});
 
-        auto costs    = std::vector<real_t>{1, 2, 3, 4, 5, 6, 7};
+        auto costs = std::vector<real_t>{1.0_F, 2.0_F, 3.0_F, 4.0_F, 5.0_F, 6.0_F, 7.0_F};
 
-        auto inst     = Instance();
-        inst.cols     = std::move(cols);
-        inst.costs    = std::move(costs);
+        auto inst  = Instance();
+        inst.cols  = std::move(cols);
+        inst.costs = std::move(costs);
         inst.rows.resize(nrows);
 
         return inst;
@@ -37,14 +39,14 @@ namespace local { namespace {
 
 TEST_CASE("Test fill_rows_from_cols") {
     auto inst = local::make_partial_inst();
-    REQUIRE_NOTHROW(fill_rows_from_cols(inst.cols, inst.rows.size(), inst.rows));
+    REQUIRE_NOTHROW(fill_rows_from_cols(inst.cols, rsize(inst.rows), inst.rows));
     REQUIRE_NOTHROW(col_and_rows_check(inst.cols, inst.rows));
 }
 
 TEST_CASE("Test fill_rows_from_cols fail") {
     auto inst = local::make_partial_inst();
-    REQUIRE_NOTHROW(fill_rows_from_cols(inst.cols, inst.rows.size(), inst.rows));
-    inst.rows.back().push_back(0);
+    REQUIRE_NOTHROW(fill_rows_from_cols(inst.cols, rsize(inst.rows), inst.rows));
+    inst.rows.back().push_back(0_C);
     REQUIRE_THROWS_AS(col_and_rows_check(inst.cols, inst.rows), std::runtime_error);
 }
 #endif
@@ -52,7 +54,7 @@ TEST_CASE("Test fill_rows_from_cols fail") {
 TEST_CASE("Test push_back_col_from") {
     auto inst1 = local::make_partial_inst();
     auto inst2 = local::make_partial_inst();
-    REQUIRE_NOTHROW(push_back_col_from(inst1, 0, inst2));
+    REQUIRE_NOTHROW(push_back_col_from(inst1, 0_C, inst2));
     REQUIRE(inst2.cols.size() == inst1.cols.size() + 1);
 
     auto last_col = inst2.cols[inst2.cols.size() - 1];

--- a/test/Refinement_unittests.cpp
+++ b/test/Refinement_unittests.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
 // SPDX-License-Identifier: MIT
 
+#define CATCH_CONFIG_MAIN 
 #include <catch2/catch.hpp>
 
 #include "algorithms/Refinement.hpp"
@@ -21,7 +22,7 @@ TEST_CASE("Whole algorithm run test", "[Refinement]") {
 
     SECTION("Test with easy instances") {
         for (int n = 0; n < 100; ++n) {
-            auto inst = make_easy_inst(n, 1000);
+            auto inst = make_easy_inst(n, 1000_C);
             auto sol  = run(env, inst, init_sol);
             REQUIRE(sol.cost <= 1000.0_F);                  // Trivial bad solution has 1000 cost
             REQUIRE(sol.cost >= as_real(sol.idxs.size()));  // Min col cost is 1.0

--- a/test/SortedArray_unittests.cpp
+++ b/test/SortedArray_unittests.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
 // SPDX-License-Identifier: MIT
 
+#define CATCH_CONFIG_MAIN 
 #include <catch2/catch.hpp>
 
 #include "utils/SortedArray.hpp"

--- a/test/Span_unittests.cpp
+++ b/test/Span_unittests.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
 // SPDX-License-Identifier: MIT
 
+#define CATCH_CONFIG_MAIN 
 #include <catch2/catch.hpp>
 
 #include "utils/Span.hpp"

--- a/test/StringView_unittests.cpp
+++ b/test/StringView_unittests.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
 // SPDX-License-Identifier: MIT
 
+#define CATCH_CONFIG_MAIN 
 #include <catch2/catch.hpp>
 
 #include "utils/StringView.hpp"

--- a/test/TaggedScalar.hpp
+++ b/test/TaggedScalar.hpp
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#ifndef CFT_INCLUDE_UTILS_TAGGEDSCALAR_HPP
+#define CFT_INCLUDE_UTILS_TAGGEDSCALAR_HPP
+
+#include <cassert>
+
+#ifndef NDEBUG
+#include <cmath>
+#endif
+
+namespace ext {
+// TaggedScalar wraps a native arithmetic type and define almost all conversion as explicit. The
+// only implicit conversion allowed is from TaggedScalar<T> to T.
+// It can be considered as a "soft" type-safe wrapper.
+template <typename T, typename TAG>
+struct TaggedScalar {
+    using type = T;
+    T value;
+
+    constexpr TaggedScalar() = default;
+
+    constexpr explicit TaggedScalar(T val)
+        : value(val) {
+    }
+
+    // This must be implicit for the abstraction to work
+    constexpr operator T() const {
+        return assert(std::isfinite(value)), value;
+    }
+};
+
+template <typename T, typename TagT>
+constexpr TaggedScalar<T, TagT> operator+(TaggedScalar<T, TagT> n) {
+    return assert(std::isfinite(n.value)), n;
+}
+
+template <typename T, typename TagT>
+constexpr TaggedScalar<T, TagT> operator-(TaggedScalar<T, TagT> n) {
+    return assert(std::isfinite(-n.value)), TaggedScalar<T, TagT>(-n.value);
+}
+
+template <typename T, typename TagT>
+constexpr TaggedScalar<T, TagT>& operator++(TaggedScalar<T, TagT>& n) {
+    return ++n.value, assert(std::isfinite(n.value)), n;
+}
+
+template <typename T, typename TagT>
+constexpr TaggedScalar<T, TagT>& operator--(TaggedScalar<T, TagT>& n) {
+    return --n.value, assert(std::isfinite(n.value)), n;
+}
+
+template <typename T, typename TagT>
+TaggedScalar<T, TagT> operator++(TaggedScalar<T, TagT>& n, int) {
+    auto old = n;
+    ++n.value;
+    assert(std::isfinite(n.value));
+    return old;
+}
+
+template <typename T, typename TagT>
+TaggedScalar<T, TagT> operator--(TaggedScalar<T, TagT>& n, int) {
+    auto old = n;
+    --n.value;
+    assert(std::isfinite(n.value));
+    return old;
+}
+
+template <typename T, typename TagT>
+constexpr TaggedScalar<T, TagT> operator+(TaggedScalar<T, TagT> n, TaggedScalar<T, TagT> other) {
+    return TaggedScalar<T, TagT>(n.value + other.value);
+}
+
+template <typename T, typename TagT>
+constexpr TaggedScalar<T, TagT> operator-(TaggedScalar<T, TagT> n, TaggedScalar<T, TagT> other) {
+    return TaggedScalar<T, TagT>(n.value - other.value);
+}
+
+template <typename T, typename TagT>
+constexpr TaggedScalar<T, TagT> operator*(TaggedScalar<T, TagT> n, TaggedScalar<T, TagT> other) {
+    return TaggedScalar<T, TagT>(n.value * other.value);
+}
+
+template <typename T, typename TagT>
+constexpr TaggedScalar<T, TagT> operator/(TaggedScalar<T, TagT> n, TaggedScalar<T, TagT> other) {
+    return TaggedScalar<T, TagT>(n.value / other.value);
+}
+
+template <typename T, typename TagT>
+constexpr TaggedScalar<T, TagT>& operator+=(TaggedScalar<T, TagT>& n, TaggedScalar<T, TagT> other) {
+    return n.value += other.value, n;
+}
+
+template <typename T, typename TagT>
+constexpr TaggedScalar<T, TagT>& operator-=(TaggedScalar<T, TagT>& n, TaggedScalar<T, TagT> other) {
+    return n.value -= other.value, n;
+}
+
+template <typename T, typename TagT>
+constexpr TaggedScalar<T, TagT>& operator*=(TaggedScalar<T, TagT>& n, TaggedScalar<T, TagT> other) {
+    return n.value *= other.value, n;
+}
+
+template <typename T, typename TagT>
+constexpr TaggedScalar<T, TagT>& operator/=(TaggedScalar<T, TagT>& n, TaggedScalar<T, TagT> other) {
+    return n.value /= other.value, n;
+}
+
+template <typename T, typename TagT>
+constexpr bool operator<(TaggedScalar<T, TagT> n, TaggedScalar<T, TagT> other) {
+    return n.value < other.value;
+}
+
+template <typename T, typename TagT>
+constexpr bool operator>(TaggedScalar<T, TagT> n, TaggedScalar<T, TagT> other) {
+    return n.value > other.value;
+}
+
+template <typename T, typename TagT>
+constexpr bool operator<=(TaggedScalar<T, TagT> n, TaggedScalar<T, TagT> other) {
+    return n.value <= other.value;
+}
+
+template <typename T, typename TagT>
+constexpr bool operator>=(TaggedScalar<T, TagT> n, TaggedScalar<T, TagT> other) {
+    return n.value >= other.value;
+}
+
+template <typename T, typename TagT>
+constexpr bool operator==(TaggedScalar<T, TagT> n, TaggedScalar<T, TagT> other) {
+    return n.value == other.value;
+}
+
+template <typename T, typename TagT>
+constexpr bool operator!=(TaggedScalar<T, TagT> n, TaggedScalar<T, TagT> other) {
+    return n.value != other.value;
+}
+
+// Delete any operation between a TaggedScalar and any other type
+template <typename T1, typename Tag1>
+bool operator!(TaggedScalar<T1, Tag1>) = delete;
+
+template <typename T1, typename Tag1, typename T2>
+TaggedScalar<T1, Tag1> operator+(TaggedScalar<T1, Tag1>, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+TaggedScalar<T1, Tag1> operator+(T2, TaggedScalar<T1, Tag1>) = delete;
+template <typename T1, typename Tag1, typename T2>
+TaggedScalar<T1, Tag1> operator-(TaggedScalar<T1, Tag1>, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+TaggedScalar<T1, Tag1> operator-(T2, TaggedScalar<T1, Tag1>) = delete;
+template <typename T1, typename Tag1, typename T2>
+TaggedScalar<T1, Tag1> operator*(TaggedScalar<T1, Tag1>, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+TaggedScalar<T1, Tag1> operator*(T2, TaggedScalar<T1, Tag1>) = delete;
+template <typename T1, typename Tag1, typename T2>
+TaggedScalar<T1, Tag1> operator/(TaggedScalar<T1, Tag1>, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+TaggedScalar<T1, Tag1> operator/(T2, TaggedScalar<T1, Tag1>) = delete;
+template <typename T1, typename Tag1, typename T2>
+TaggedScalar<T1, Tag1>& operator+=(TaggedScalar<T1, Tag1>&, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+TaggedScalar<T1, Tag1>& operator+=(T2&, TaggedScalar<T1, Tag1>) = delete;
+template <typename T1, typename Tag1, typename T2>
+TaggedScalar<T1, Tag1>& operator-=(TaggedScalar<T1, Tag1>&, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+TaggedScalar<T1, Tag1>& operator-=(T2&, TaggedScalar<T1, Tag1>) = delete;
+template <typename T1, typename Tag1, typename T2>
+TaggedScalar<T1, Tag1>& operator*=(TaggedScalar<T1, Tag1>&, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+TaggedScalar<T1, Tag1>& operator*=(T2&, TaggedScalar<T1, Tag1>) = delete;
+template <typename T1, typename Tag1, typename T2>
+TaggedScalar<T1, Tag1>& operator/=(TaggedScalar<T1, Tag1>&, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+TaggedScalar<T1, Tag1>& operator/=(T2&, TaggedScalar<T1, Tag1>) = delete;
+
+template <typename T1, typename Tag1, typename T2>
+bool operator<(TaggedScalar<T1, Tag1>, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator<(T2, TaggedScalar<T1, Tag1>) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator>(TaggedScalar<T1, Tag1>, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator>(T2, TaggedScalar<T1, Tag1>) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator<=(TaggedScalar<T1, Tag1>, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator<=(T2, TaggedScalar<T1, Tag1>) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator>=(TaggedScalar<T1, Tag1>, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator>=(T2, TaggedScalar<T1, Tag1>) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator==(TaggedScalar<T1, Tag1>, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator==(T2, TaggedScalar<T1, Tag1>) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator!=(TaggedScalar<T1, Tag1>, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator!=(T2, TaggedScalar<T1, Tag1>) = delete;
+
+template <typename T1, typename Tag1, typename T2>
+bool operator>>(TaggedScalar<T1, Tag1>, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator>>(T2, TaggedScalar<T1, Tag1>) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator<<(TaggedScalar<T1, Tag1>, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator<<(T2, TaggedScalar<T1, Tag1>) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator^(TaggedScalar<T1, Tag1>, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator^(T2, TaggedScalar<T1, Tag1>) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator|(TaggedScalar<T1, Tag1>, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator|(T2, TaggedScalar<T1, Tag1>) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator&(TaggedScalar<T1, Tag1>, T2) = delete;
+template <typename T1, typename Tag1, typename T2>
+bool operator&(T2, TaggedScalar<T1, Tag1>) = delete;
+
+}  // namespace ext
+
+
+#endif /* CFT_INCLUDE_UTILS_TAGGEDSCALAR_HPP */

--- a/test/cft_unittests.cpp
+++ b/test/cft_unittests.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
 // SPDX-License-Identifier: MIT
 
+#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
 #include "core/cft.hpp"
@@ -63,14 +64,14 @@ TEST_CASE("Test rsize function", "[cft]") {
 TEST_CASE("Test as_cidx function failure ", "[cft]") {
     if (static_cast<uint64_t>(limits<cidx_t>::max()) < limits<uint64_t>::max())
         REQUIRE_THROWS_AS(as_cidx(limits<uint64_t>::max()), std::runtime_error);
-    if (!std::is_signed<cidx_t>::value)
+    if (!std::is_signed<native_t<cidx_t>>::value)
         REQUIRE_THROWS_AS(as_cidx(-1), std::runtime_error);
 }
 
 TEST_CASE("Test as_ridx function failure ", "[cft]") {
     if (static_cast<uint64_t>(limits<ridx_t>::max()) < limits<uint64_t>::max())
         REQUIRE_THROWS_AS(as_ridx(limits<uint64_t>::max()), std::runtime_error);
-    if (!std::is_signed<ridx_t>::value)
+    if (!std::is_signed<native_t<ridx_t>>::value)
         REQUIRE_THROWS_AS(as_ridx(-1), std::runtime_error);
 }
 

--- a/test/coverage_unittests.cpp
+++ b/test/coverage_unittests.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
 // SPDX-License-Identifier: MIT
 
+#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 #include <cstring>
 
@@ -16,50 +17,53 @@ namespace cft {
 
 TEST_CASE("test_single_row_cover_set_coverage") {
 
-    ridx_t nrows = 99;
-    cidx_t ncols = 6;
+    ridx_t nrows = 99_R;
+    cidx_t ncols = 6_C;
 
     auto cols = SparseBinMat<ridx_t>();
-    cols.push_back({81, 97, 12, 84, 88, 50, 62, 46, 25, 4, 40, 16, 98, 63});
-    cols.push_back({70, 95, 53, 86, 71, 10, 26, 33, 39, 61, 54, 92, 31, 90, 24, 28, 30, 72});
-    cols.push_back({66, 32, 35, 22, 78, 29, 20, 11, 48, 1, 42, 75, 41, 38, 44, 2, 7, 77, 69});
-    cols.push_back({19, 87, 9, 60, 93, 83, 15, 79, 37, 51, 49, 3, 21, 58});
-    cols.push_back({13, 57, 14, 82, 73, 64, 85, 47, 6, 96, 45, 65, 74, 18, 27, 17, 43, 8});
-    cols.push_back({5, 91, 34, 55, 0, 23, 36, 56, 80, 68, 67, 59, 94, 76, 52, 89});
+    cols.push_back({81_R, 97_R, 12_R, 84_R, 88_R, 50_R, 62_R, 46_R, 25_R, 4_R, 40_R, 16_R, 98_R});
+    cols.push_back({70_R, 95_R, 53_R, 86_R, 71_R, 10_R, 26_R, 33_R, 39_R, 61_R, 54_R, 92_R, 31_R});
+    cols.push_back({66_R, 32_R, 35_R, 22_R, 78_R, 29_R, 20_R, 11_R, 48_R, 1_R, 42_R, 75_R, 41_R});
+    cols.push_back({19_R, 87_R, 9_R, 60_R, 93_R, 83_R, 15_R, 79_R, 37_R, 51_R, 49_R, 3_R, 21_R});
+    cols.push_back({13_R, 57_R, 14_R, 82_R, 73_R, 64_R, 85_R, 47_R, 6_R, 96_R, 45_R, 65_R, 74_R});
+    cols.push_back({5_R, 91_R, 34_R, 55_R, 0_R, 23_R, 36_R, 56_R, 80_R, 68_R, 67_R, 59_R, 94_R});
+    cols.push_back({63_R, 90_R, 24_R, 28_R, 30_R, 72_R, 38_R, 44_R, 2_R, 7_R, 77_R});
+    cols.push_back({69_R, 58_R, 18_R, 27_R, 17_R, 43_R, 8_R, 76_R, 52_R, 89_R});
+
 
     auto cs = CoverCounters(nrows);
     REQUIRE(cs.cover(cols.idxs) == static_cast<size_t>(nrows));
 
     cs.reset(nrows);
-    for (ridx_t i = 0; i < nrows; ++i)
+    for (ridx_t i = 0_R; i < nrows; ++i)
         REQUIRE(cs[i] == 0);
-    for (cidx_t j = 0; j < ncols; ++j)
+    for (cidx_t j = 0_C; j < ncols; ++j)
         REQUIRE(cs.cover(cols[j]) == cols[j].size());
 }
 
 TEST_CASE("test_multiples_rows_cover_set_coverage") {
 
-    ridx_t nrows = 40;
-    cidx_t ncols = 7;
+    ridx_t nrows = 40_R;
+    cidx_t ncols = 7_C;
 
     auto cols = SparseBinMat<ridx_t>();
-    cols.push_back({1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
-    cols.push_back({11, 12, 13, 14, 15, 16, 17, 18, 19, 20});
-    cols.push_back({21, 22, 23, 24, 25, 26, 27, 28, 29, 30});
-    cols.push_back({31, 32, 33, 34, 35, 36, 37, 38, 39, 0});
-    cols.push_back({1, 11, 21, 31, 2, 12, 22, 32});
-    cols.push_back({3, 13, 23, 33, 4, 14, 24, 34});
-    cols.push_back({5, 15, 25, 35, 6, 16, 26, 36});
+    cols.push_back({1_R, 2_R, 3_R, 4_R, 5_R, 6_R, 7_R, 8_R, 9_R, 10_R});
+    cols.push_back({11_R, 12_R, 13_R, 14_R, 15_R, 16_R, 17_R, 18_R, 19_R, 20_R});
+    cols.push_back({21_R, 22_R, 23_R, 24_R, 25_R, 26_R, 27_R, 28_R, 29_R, 30_R});
+    cols.push_back({31_R, 32_R, 33_R, 34_R, 35_R, 36_R, 37_R, 38_R, 39_R, 0_R});
+    cols.push_back({1_R, 11_R, 21_R, 31_R, 2_R, 12_R, 22_R, 32_R});
+    cols.push_back({3_R, 13_R, 23_R, 33_R, 4_R, 14_R, 24_R, 34_R});
+    cols.push_back({5_R, 15_R, 25_R, 35_R, 6_R, 16_R, 26_R, 36_R});
 
     auto cs = CoverCounters(nrows);
     REQUIRE(cs.cover(cols.idxs) == static_cast<size_t>(nrows));
 
     cs.reset(nrows);
-    for (ridx_t i = 0; i < rsize(cs); ++i)
+    for (ridx_t i = 0_R; i < rsize(cs); ++i)
         REQUIRE(cs[i] == 0);
-    for (cidx_t j = 0; j < 4; ++j)
+    for (cidx_t j = 0_C; j < 4_C; ++j)
         REQUIRE(cs.cover(cols[j]) == cols[j].size());
-    for (cidx_t j = 4; j < csize(cols); ++j) {
+    for (cidx_t j = 4_C; j < csize(cols); ++j) {
         REQUIRE(cs.is_redundant_cover(cols[j]));
         REQUIRE(!cs.is_redundant_uncover(cols[j]));
         REQUIRE(cs.cover(cols[j]) == 0);
@@ -80,9 +84,9 @@ TEST_CASE("test_multiples_rows_cover_set_coverage") {
 
     size_t cover_count = 0;
     size_t nnz         = 0;
-    for (ridx_t i = 0; i < rsize(cs); ++i)
+    for (ridx_t i = 0_R; i < rsize(cs); ++i)
         cover_count += cs[i];
-    for (cidx_t j = 0; j < ncols; ++j)
+    for (cidx_t j = 0_C; j < ncols; ++j)
         nnz += cols[j].size();
     REQUIRE(cover_count == nnz);
 }
@@ -90,7 +94,7 @@ TEST_CASE("test_multiples_rows_cover_set_coverage") {
 #ifndef NDEBUG
 
 TEST_CASE("Test coverage assert fails") {
-    ridx_t nrows = 40;
+    ridx_t nrows = 40_R;
 
     auto cols = SparseBinMat<int>();
     cols.push_back({40, 12, 13, 14, 15, 40, 17, 18, 19, 20});   // 40!
@@ -99,12 +103,12 @@ TEST_CASE("Test coverage assert fails") {
     cols.push_back({-5, 15, 25, 35, 6, 1, 26, 36});             // -5!
 
     auto cs = CoverCounters(nrows);
-    for (cidx_t j = 0; j < 4; ++j) {
+    for (cidx_t j = 0_C; j < 4; ++j) {
         REQUIRE_THROWS_AS(cs.cover(cols[j]), std::runtime_error);
         REQUIRE_THROWS_AS(cs.is_redundant_cover(cols[j]), std::runtime_error);
     }
 
-    for (cidx_t j = 0; j < 4; ++j) {
+    for (cidx_t j = 0_C; j < 4; ++j) {
         REQUIRE_THROWS_AS(cs.uncover(cols[j]), std::runtime_error);
         REQUIRE_THROWS_AS(cs.is_redundant_uncover(cols[j]), std::runtime_error);
     }

--- a/test/custom_types_unittests.cpp
+++ b/test/custom_types_unittests.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include "utils/custom_types.hpp"
+
+// NOTE1: DO NOT MIX DIFFERENT CUSTOM TYPES IN THE SAME BINARY (I.E.: DO NOT LINK TOGETHER
+//        TRANSLATION UNITS THAT USE DIFFERENT CUSTOM TYPES)
+// NOTE2: This is an advanced feature that requires a good understanding of the C++ type system.
+
+
+// This test file serves as an example of how we can customize the basic types (cidx_t, ridx_t, and
+// real_t) used in the algorithm. We can replace these types with more advanced ones that provide
+// additional features, such as preventing implicit casts or applying custom checks during
+// mathematical operations. However, it is important to note that these custom types must still be
+// implicitly convertible to the native type they represent, in order to allow conversions to array
+// indexes, for example.
+
+// To demonstrate how to customize basic types, we provide an example called `TaggedScalar`.
+// `TaggedScalar` wraps a native type and it is uniquelly identified by a second template parameter
+// called "TAG".
+// It prohibits implicit conversions between a `TaggedScalar` and any other type, including other
+// `TaggedScalar` with a different tag. Comparison and basic operations with the corresponding
+// native type are also deleted. The only implicit conversion allowed is to the respective native
+// type for compatibility with existing functions. Even constructing a `TaggedScalar` from its
+// native type must be explicit.
+#include "TaggedScalar.hpp"
+
+// Before including `cft.hpp`, we need to define macros for the custom types we want to use in order
+// to customize the entire algorithm. In this case, we are defining all three types.
+#define CFT_CIDX_TYPE ext::TaggedScalar<int32_t, struct COL>
+#define CFT_RIDX_TYPE ext::TaggedScalar<int16_t, struct ROW>
+#define CFT_REAL_TYPE ext::TaggedScalar<float, struct REAL>
+
+// In order to enable operations like printing, parsing from files, random value generation, and
+// other low-level operations that might be defined only for the C++ numeric types, we need to
+// define the conversion to the corresponding C++ native type. This can be achieved by partially
+// specializing the `native` template struct. Since we are using the same template (`TaggedScalar`)
+// for cidx_t, ridx_t, and real_t, we can define a single partial specialization that matches any
+// instantiation of `TaggedScalar`.
+namespace cft {
+template <typename T, typename TAG>
+struct native<ext::TaggedScalar<T, TAG>> {
+    using type = T;
+};
+}  // namespace cft
+
+// Now we can include the CFT headers, which will automatically adapt to our custom type
+// definitions.
+#include "algorithms/Refinement.hpp"
+#include "core/cft.hpp"
+#include "test_utils.hpp"
+
+namespace cft {
+
+TEST_CASE("Custom types, whole algorithm run test", "[Refinement]") {
+    auto env       = Environment();
+    env.time_limit = 10.0;
+    env.heur_iters = 100;
+    env.verbose    = 2;
+    auto init_sol  = Solution();
+    init_sol.idxs  = std::vector<cidx_t>{0_C, 1_C, 2_C, 3_C, 4_C, 5_C, 6_C, 7_C, 8_C, 9_C};
+    init_sol.cost  = 1000.0_F;
+
+    SECTION("Test with easy instances") {
+        for (int n = 0; n < 20; ++n) {
+            auto inst = make_easy_inst(n, 100_C);
+            auto sol  = run(env, inst, init_sol);
+            REQUIRE((sol.cost <= 1000.0_F));                  // Trivial bad solution has 1000 cost
+            REQUIRE((sol.cost >= as_real(sol.idxs.size())));  // Min col cost is 1.0
+            if ((abs(sol.cost - 1000.0_F) < 1e-6_F))
+                REQUIRE_THAT(sol.idxs, Catch::Matchers::UnorderedEquals(init_sol.idxs));
+            CFT_IF_DEBUG(REQUIRE_NOTHROW(check_inst_solution(inst, sol)));
+        }
+    }
+}
+
+}  // namespace cft

--- a/test/large_types_unittests.cpp
+++ b/test/large_types_unittests.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#define CFT_CIDX_TYPE uint64_t
+#define CFT_RIDX_TYPE int64_t
+#define CFT_REAL_TYPE long double
+
+#include "algorithms/Refinement.hpp"
+#include "core/cft.hpp"
+#include "test_utils.hpp"
+
+namespace cft {
+
+TEST_CASE("Custom types, whole algorithm run test", "[Refinement]") {
+    auto env       = Environment();
+    env.time_limit = 10.0;
+    env.heur_iters = 100;
+    env.verbose    = 2;
+    auto init_sol  = Solution();
+    init_sol.idxs  = std::vector<cidx_t>{0_C, 1_C, 2_C, 3_C, 4_C, 5_C, 6_C, 7_C, 8_C, 9_C};
+    init_sol.cost  = 1000.0_F;
+
+    SECTION("Test with easy instances") {
+        for (int n = 0; n < 20; ++n) {
+            auto inst = make_easy_inst(n, 100_C);
+            auto sol  = run(env, inst, init_sol);
+            REQUIRE((sol.cost <= 1000.0_F));                  // Trivial bad solution has 1000 cost
+            REQUIRE((sol.cost >= as_real(sol.idxs.size())));  // Min col cost is 1.0
+            if ((abs(sol.cost - 1000.0_F) < 1e-6_F))
+                REQUIRE_THAT(sol.idxs, Catch::Matchers::UnorderedEquals(init_sol.idxs));
+            CFT_IF_DEBUG(REQUIRE_NOTHROW(check_inst_solution(inst, sol)));
+        }
+    }
+}
+
+}  // namespace cft

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,5 +1,0 @@
-// SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
-// SPDX-License-Identifier: MIT
-
-#define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
-#include <catch2/catch.hpp>

--- a/test/parse_utils_unittests.cpp
+++ b/test/parse_utils_unittests.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
 // SPDX-License-Identifier: MIT
 
+#define CATCH_CONFIG_MAIN 
 #include <catch2/catch.hpp>
 
 #include "utils/parse_utils.hpp"

--- a/test/parsing_unittests.cpp
+++ b/test/parsing_unittests.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
 // SPDX-License-Identifier: MIT
 
+#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 #include <stdexcept>
 
@@ -24,47 +25,47 @@ TEST_CASE("test_parse_scp_instance") {
     auto inst = Instance();
     REQUIRE_NOTHROW(inst = parse_scp_instance("../instances/scp/scp41.txt"));
 
-    REQUIRE(rsize(inst.rows) == 200);
-    REQUIRE(csize(inst.cols) == 1000);
+    REQUIRE(rsize(inst.rows) == 200_R);
+    REQUIRE(csize(inst.cols) == 1000_C);
 
     REQUIRE(inst.cols[0].size() == 8);
-    REQUIRE_THAT(
-        local::span_to_vector<ridx_t>(inst.cols[0]),
-        Catch::Matchers::UnorderedEquals(std::vector<ridx_t>{17, 31, 74, 75, 106, 189, 195, 198}));
+    REQUIRE_THAT(local::span_to_vector<ridx_t>(inst.cols[0]),
+                 Catch::Matchers::UnorderedEquals(
+                     std::vector<ridx_t>{17_R, 31_R, 74_R, 75_R, 106_R, 189_R, 195_R, 198_R}));
 
     REQUIRE(csize(inst.cols) == csize(inst.costs));
-    REQUIRE(std::fabs(inst.costs[0] - 1.0_F) < 0.01_F);
+    REQUIRE(abs(inst.costs[0] - 1.0_F) < 0.01_F);
 }
 
 TEST_CASE("test_parse_rail_instance") {
     auto inst = Instance();
     REQUIRE_NOTHROW(inst = parse_rail_instance("../instances/rail/rail507"));
 
-    REQUIRE(rsize(inst.rows) == 507);
-    REQUIRE(csize(inst.cols) == 63009);
+    REQUIRE(rsize(inst.rows) == 507_R);
+    REQUIRE(csize(inst.cols) == 63009_C);
 
     REQUIRE(inst.cols[0].size() == 7);
-    REQUIRE_THAT(
-        local::span_to_vector<ridx_t>(inst.cols[0]),
-        Catch::Matchers::UnorderedEquals(std::vector<ridx_t>{41, 42, 43, 317, 318, 421, 422}));
+    REQUIRE_THAT(local::span_to_vector<ridx_t>(inst.cols[0]),
+                 Catch::Matchers::UnorderedEquals(
+                     std::vector<ridx_t>{41_R, 42_R, 43_R, 317_R, 318_R, 421_R, 422_R}));
 
     REQUIRE(csize(inst.cols) == csize(inst.costs));
-    REQUIRE(std::fabs(inst.costs[0] - 2.0_F) < 0.01_F);
+    REQUIRE(abs(inst.costs[0] - 2.0_F) < 0.01_F);
 }
 
 TEST_CASE("test_parse_cvrp_instance") {
     auto  fdata = parse_cvrp_instance("../instances/cvrp/X-n536-k96_z95480_cplex95479.scp");
     auto& inst  = fdata.inst;
-    REQUIRE(rsize(inst.rows) == 535);
-    REQUIRE(csize(inst.cols) == 127262);
+    REQUIRE(rsize(inst.rows) == 535_R);
+    REQUIRE(csize(inst.cols) == 127262_C);
 
-    REQUIRE(inst.cols[0].size() == 1);
-    REQUIRE(inst.cols[1].size() == 4);
+    REQUIRE(rsize(inst.cols[0]) == 1_R);
+    REQUIRE(rsize(inst.cols[1]) == 4_R);
     REQUIRE_THAT(local::span_to_vector<ridx_t>(inst.cols[1]),
-                 Catch::Matchers::UnorderedEquals(std::vector<ridx_t>{486, 526, 320, 239}));
+                 Catch::Matchers::UnorderedEquals(std::vector<ridx_t>{486_R, 526_R, 320_R, 239_R}));
 
     REQUIRE(csize(inst.cols) == csize(inst.costs));
-    REQUIRE(std::fabs(inst.costs[1] - 787.0_F) < 0.01_F);
+    REQUIRE(abs(inst.costs[1] - 787.0_F) < 0.01_F);
 
     REQUIRE(!fdata.init_sol.idxs.empty());
 }
@@ -73,17 +74,29 @@ TEST_CASE("test_parse_mps_instance") {
     auto inst = Instance();
     REQUIRE_NOTHROW(inst = parse_mps_instance("../instances/mps/ramos3.mps"));
 
-    REQUIRE(rsize(inst.rows) == 2187);
-    REQUIRE(csize(inst.cols) == 2187);
+    REQUIRE(rsize(inst.rows) == 2187_R);
+    REQUIRE(csize(inst.cols) == 2187_C);
 
-    REQUIRE(inst.cols[0].size() == 15);
-    REQUIRE_THAT(
-        local::span_to_vector<ridx_t>(inst.cols[0]),
-        Catch::Matchers::UnorderedEquals(
-            std::vector<ridx_t>{0, 9, 10, 11, 12, 15, 18, 36, 63, 90, 171, 252, 495, 738, 1467}));
+    REQUIRE(rsize(inst.cols[0]) == 15_R);
+    REQUIRE_THAT(local::span_to_vector<ridx_t>(inst.cols[0]),
+                 Catch::Matchers::UnorderedEquals(std::vector<ridx_t>{0_R,
+                                                                      9_R,
+                                                                      10_R,
+                                                                      11_R,
+                                                                      12_R,
+                                                                      15_R,
+                                                                      18_R,
+                                                                      36_R,
+                                                                      63_R,
+                                                                      90_R,
+                                                                      171_R,
+                                                                      252_R,
+                                                                      495_R,
+                                                                      738_R,
+                                                                      1467_R}));
 
     REQUIRE(csize(inst.cols) == csize(inst.costs));
-    REQUIRE(std::fabs(inst.costs[0] - 1.0_F) < 0.01_F);
+    REQUIRE(abs(inst.costs[0] - 1.0_F) < 0.01_F);
 }
 
 TEST_CASE("test wrong parser") {
@@ -113,14 +126,14 @@ TEST_CASE("Test parse_solution", "[parsing]") {
     SECTION("write_solution and read_solution") {
         auto path = std::string("test_solution.txt");
         auto wsol = cft::Solution();
-        wsol.cost = 101.5;
-        wsol.idxs = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+        wsol.cost = 101.5_F;
+        wsol.idxs = {1_C, 2_C, 3_C, 4_C, 5_C, 6_C, 7_C, 8_C, 9_C};
 
         cft::write_solution(path, wsol);
         cft::Solution sol = cft::parse_solution(path);
 
-        REQUIRE(sol.cost == 101.5);
-        REQUIRE(sol.idxs == std::vector<cft::cidx_t>{1, 2, 3, 4, 5, 6, 7, 8, 9});
+        REQUIRE((101.49_F < sol.cost && sol.cost < 101.51_F));
+        REQUIRE(sol.idxs == std::vector<cft::cidx_t>{1_C, 2_C, 3_C, 4_C, 5_C, 6_C, 7_C, 8_C, 9_C});
 
         std::remove(path.c_str());
     }
@@ -139,8 +152,8 @@ TEST_CASE("Test parse_solution", "[parsing]") {
     SECTION("Write solution: Invalid file path") {
         auto path = std::string("/invalid/path/test_solution.txt");
         auto sol  = cft::Solution();
-        sol.cost  = 10.5;
-        sol.idxs  = {1, 2, 3};
+        sol.cost  = 10.5_F;
+        sol.idxs  = {1_C, 2_C, 3_C};
 
         REQUIRE_THROWS_AS(cft::write_solution(path, sol), std::exception);
     }
@@ -166,9 +179,9 @@ TEST_CASE("parse_inst_and_initsol") {
         write_solution(env.initsol_path, sol);
         auto fdata = parse_inst_and_initsol(env);
 
-        REQUIRE(rsize(fdata.inst.rows) == 200);
-        REQUIRE(csize(fdata.inst.cols) == 1000);
-        REQUIRE(fdata.init_sol.cost == 429.0_F);
+        REQUIRE(rsize(fdata.inst.rows) == 200_R);
+        REQUIRE(csize(fdata.inst.cols) == 1000_C);
+        REQUIRE((428.99_F < fdata.init_sol.cost && fdata.init_sol.cost < 429.01_F));
         REQUIRE_THAT(sol.idxs, Catch::Matchers::UnorderedEquals(fdata.init_sol.idxs));
         std::remove(env.initsol_path.c_str());
     }
@@ -199,9 +212,9 @@ TEST_CASE("parse_inst_and_initsol") {
         write_solution(env.initsol_path, sol);
         auto fdata = parse_inst_and_initsol(env);
 
-        REQUIRE(rsize(fdata.inst.rows) == 507);
-        REQUIRE(csize(fdata.inst.cols) == 63009);
-        REQUIRE(fdata.init_sol.cost == 174.0_F);
+        REQUIRE(rsize(fdata.inst.rows) == 507_R);
+        REQUIRE(csize(fdata.inst.cols) == 63009_C);
+        REQUIRE(abs(fdata.init_sol.cost - 174.0_F) <= 0.01_F);
         REQUIRE_THAT(sol.idxs, Catch::Matchers::UnorderedEquals(fdata.init_sol.idxs));
         std::remove(env.initsol_path.c_str());
 
@@ -231,9 +244,9 @@ TEST_CASE("parse_inst_and_initsol") {
         write_solution(env.initsol_path, sol);
         auto fdata = parse_inst_and_initsol(env);
 
-        REQUIRE(rsize(fdata.inst.rows) == 535);
-        REQUIRE(csize(fdata.inst.cols) == 127262);
-        REQUIRE(fdata.init_sol.cost == 95480.0_F);
+        REQUIRE(rsize(fdata.inst.rows) == 535_R);
+        REQUIRE(csize(fdata.inst.cols) == 127262_C);
+        REQUIRE(abs(fdata.init_sol.cost - 95480.0_F) < 0.01_F);
         REQUIRE_THAT(sol.idxs, Catch::Matchers::UnorderedEquals(fdata.init_sol.idxs));
         std::remove(env.initsol_path.c_str());
     }
@@ -270,9 +283,9 @@ TEST_CASE("parse_inst_and_initsol") {
         write_solution(env.initsol_path, sol);
         auto fdata = parse_inst_and_initsol(env);
 
-        REQUIRE(rsize(fdata.inst.rows) == 2187);
-        REQUIRE(csize(fdata.inst.cols) == 2187);
-        REQUIRE(fdata.init_sol.cost == 194.0_F);
+        REQUIRE(rsize(fdata.inst.rows) == 2187_R);
+        REQUIRE(csize(fdata.inst.cols) == 2187_C);
+        REQUIRE(abs(fdata.init_sol.cost - 194.0_F) < 0.01_F);
         REQUIRE_THAT(sol.idxs, Catch::Matchers::UnorderedEquals(fdata.init_sol.idxs));
         std::remove(env.initsol_path.c_str());
     }

--- a/test/random_unittests.cpp
+++ b/test/random_unittests.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
 // SPDX-License-Identifier: MIT
 
+#define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
 #include "utils/random.hpp"
@@ -42,6 +43,13 @@ TEST_CASE("test_canonical_gen") {
         REQUIRE(result4 >= 0.0);
         REQUIRE(result4 < 1.0);
         over_half += result4 > 0.5 ? 1 : 0;
+        ++total;
+
+        // Test for u64 -> f128 conversion
+        auto result5 = canonical_gen<long double>(rnd_double);
+        REQUIRE(result5 >= 0.0L);
+        REQUIRE(result5 < 1.0L);
+        over_half += result5 > 0.5L ? 1 : 0;
         ++total;
     }
     double over_half_frac = over_half / static_cast<double>(total);
@@ -92,6 +100,15 @@ TEST_CASE("test_rnd_real") {
             REQUIRE(res >= min);
             REQUIRE(res < max);
             over_half += res > (min + max) / 2.0 ? 1 : 0;
+            ++total;
+        }
+        {
+            // Test for u64 -> f64 conversion
+            long double min = -10.0L * i, max = 10.0L * i + 1;
+            auto        res = rnd_real<long double>(rnd_double, min, max);
+            REQUIRE(res >= min);
+            REQUIRE(res < max);
+            over_half += res > (min + max) / 2.0L ? 1 : 0;
             ++total;
         }
     }

--- a/test/redundancy_unittests.cpp
+++ b/test/redundancy_unittests.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
 // SPDX-License-Identifier: MIT
 
+#define CATCH_CONFIG_MAIN 
 #include <catch2/catch.hpp>
 
 #include "greedy/redundancy.hpp"
@@ -12,15 +13,15 @@ namespace cft {
 
 TEST_CASE("enumeration_removal removes redundant columns using implicit enumeration", "[cft]") {
     auto rnd  = prng_t(0);
-    auto inst = make_easy_inst(0, 1000);
+    auto inst = make_easy_inst(0, 1000_C);
     for (int k = 0; k < 1000; ++k) {
         if ((k - 1) % 10 == 0)
-            inst = make_easy_inst(k, 1000);
+            inst = make_easy_inst(k, 1000_C);
 
-        cidx_t sol_size = roll_dice(rnd, 0, min(csize(inst.cols) - 1_C, 200_C));
+        cidx_t sol_size = roll_dice(rnd, 0_C, min(csize(inst.cols) - 1_C, 200_C));
         auto   sol      = Solution();
-        for (int n = 0; n < sol_size; ++n) {
-            cidx_t j = roll_dice(rnd, 0, csize(inst.cols) - 1_C);
+        for (cidx_t n = 0_C; n < sol_size; ++n) {
+            cidx_t j = roll_dice(rnd, 0_C, csize(inst.cols) - 1_C);
             if (!any(sol.idxs, [j](cidx_t sj) { return sj == j; }))
                 sol.idxs.push_back(j);
         }
@@ -47,7 +48,7 @@ TEST_CASE("enumeration_removal removes redundant columns using implicit enumerat
             return any(red_set.cols_to_remove, [j](cidx_t r) { return r == j; });
         });
 
-        for (ridx_t i = 0; i < rsize(inst.rows); ++i)
+        for (ridx_t i = 0_R; i < rsize(inst.rows); ++i)
             REQUIRE((init_cov[i] >= red_set.total_cover[i]));
     }
 }

--- a/test/small_types_unittests.cpp
+++ b/test/small_types_unittests.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#define CFT_CIDX_TYPE int16_t
+#define CFT_RIDX_TYPE uint8_t
+#define CFT_REAL_TYPE float
+
+#include "algorithms/Refinement.hpp"
+#include "core/cft.hpp"
+#include "test_utils.hpp"
+
+namespace cft {
+
+TEST_CASE("Custom types, whole algorithm run test", "[Refinement]") {
+    auto env       = Environment();
+    env.time_limit = 10.0;
+    env.heur_iters = 100;
+    env.verbose    = 2;
+    auto init_sol  = Solution();
+    init_sol.idxs  = std::vector<cidx_t>{0_C, 1_C, 2_C, 3_C, 4_C, 5_C, 6_C, 7_C, 8_C, 9_C};
+    init_sol.cost  = 1000.0_F;
+
+    SECTION("Test with easy instances") {
+        for (int n = 0; n < 20; ++n) {
+            auto inst = make_easy_inst(n, 100_C);
+            auto sol  = run(env, inst, init_sol);
+            REQUIRE((sol.cost <= 1000.0_F));                  // Trivial bad solution has 1000 cost
+            REQUIRE((sol.cost >= as_real(sol.idxs.size())));  // Min col cost is 1.0
+            if ((abs(sol.cost - 1000.0_F) < 1e-6_F))
+                REQUIRE_THAT(sol.idxs, Catch::Matchers::UnorderedEquals(init_sol.idxs));
+            CFT_IF_DEBUG(REQUIRE_NOTHROW(check_inst_solution(inst, sol)));
+        }
+    }
+}
+
+}  // namespace cft

--- a/test/sort_unittests.cpp
+++ b/test/sort_unittests.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Francesco Cavaliere <francescocava95@gmail.com>
 // SPDX-License-Identifier: MIT
 
+#define CATCH_CONFIG_MAIN 
 #include <catch2/catch.hpp>
 #include <vector>
 

--- a/test/test_utils.hpp
+++ b/test/test_utils.hpp
@@ -15,25 +15,26 @@ namespace cft {
 inline Instance make_easy_inst(uint64_t seed, cidx_t max_ncols) {
 
     auto cols = SparseBinMat<ridx_t>();
-    cols.push_back({1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
-    cols.push_back({11, 12, 13, 14, 15, 16, 17, 18, 19, 20});
-    cols.push_back({21, 22, 23, 24, 25, 26, 27, 28, 29, 30});
-    cols.push_back({31, 32, 33, 34, 35, 36, 37, 38, 39, 40});
-    cols.push_back({41, 42, 43, 44, 45, 46, 47, 48, 49, 50});
-    cols.push_back({51, 52, 53, 54, 55, 56, 57, 58, 59, 60});
-    cols.push_back({61, 62, 63, 64, 65, 66, 67, 68, 69, 70});
-    cols.push_back({71, 72, 73, 74, 75, 76, 77, 78, 79, 80});
-    cols.push_back({81, 82, 83, 84, 85, 86, 87, 88, 89, 90});
-    cols.push_back({91, 92, 93, 94, 95, 96, 97, 98, 99, 0});
-    auto costs = std::vector<real_t>{100, 100, 100, 100, 100, 100, 100, 100, 100, 100};
+    cols.push_back({1_R, 2_R, 3_R, 4_R, 5_R, 6_R, 7_R, 8_R, 9_R, 10_R});
+    cols.push_back({11_R, 12_R, 13_R, 14_R, 15_R, 16_R, 17_R, 18_R, 19_R, 20_R});
+    cols.push_back({21_R, 22_R, 23_R, 24_R, 25_R, 26_R, 27_R, 28_R, 29_R, 30_R});
+    cols.push_back({31_R, 32_R, 33_R, 34_R, 35_R, 36_R, 37_R, 38_R, 39_R, 40_R});
+    cols.push_back({41_R, 42_R, 43_R, 44_R, 45_R, 46_R, 47_R, 48_R, 49_R, 50_R});
+    cols.push_back({51_R, 52_R, 53_R, 54_R, 55_R, 56_R, 57_R, 58_R, 59_R, 60_R});
+    cols.push_back({61_R, 62_R, 63_R, 64_R, 65_R, 66_R, 67_R, 68_R, 69_R, 70_R});
+    cols.push_back({71_R, 72_R, 73_R, 74_R, 75_R, 76_R, 77_R, 78_R, 79_R, 80_R});
+    cols.push_back({81_R, 82_R, 83_R, 84_R, 85_R, 86_R, 87_R, 88_R, 89_R, 90_R});
+    cols.push_back({91_R, 92_R, 93_R, 94_R, 95_R, 96_R, 97_R, 98_R, 99_R, 0_R});
+    auto costs = std::vector<real_t>(
+        {100.0_F, 100.0_F, 100.0_F, 100.0_F, 100.0_F, 100.0_F, 100.0_F, 100.0_F, 100.0_F, 100.0_F});
 
     auto rows = std::vector<ridx_t>{};
-    for (ridx_t i = 0; i < 100; ++i)
+    for (ridx_t i = 0_R; i < 100_R; ++i)
         rows.push_back(i);
 
-    auto rnd      = prng_t{seed};
-    int  num_cols = roll_dice(rnd, 0, max_ncols);
-    for (int i = 0; i < num_cols; ++i) {
+    auto   rnd      = prng_t{seed};
+    cidx_t num_cols = roll_dice(rnd, 0_C, max_ncols);
+    for (cidx_t i = 0_C; i < num_cols; ++i) {
         std::shuffle(rows.begin(), rows.end(), rnd);
         size_t c_size = rnd() % 10;
         cols.push_back(make_span(rows.data(), c_size));
@@ -43,7 +44,7 @@ inline Instance make_easy_inst(uint64_t seed, cidx_t max_ncols) {
     auto inst    = Instance();
     inst.cols    = std::move(cols);
     inst.costs   = std::move(costs);
-    ridx_t nrows = 100;
+    ridx_t nrows = 100_R;
     fill_rows_from_cols(inst.cols, nrows, inst.rows);
     return inst;
 }

--- a/test/utility_unittests.cpp
+++ b/test/utility_unittests.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <array>
+#define CATCH_CONFIG_MAIN 
 #include <catch2/catch.hpp>
 
 #ifndef NDEBUG
@@ -101,47 +102,29 @@ TEST_CASE("test_abs") {
 
 TEST_CASE("test_max") {
     SECTION("Integers") {
-        REQUIRE(max(1) == 1);
         REQUIRE(max(1, 2) == 2);
         REQUIRE(max(1, 2, 3) == 3);
         REQUIRE(max(3, 2, 1) == 3);
     }
 
     SECTION("Floating-point numbers") {
-        REQUIRE(max(1.0) == 1.0);
         REQUIRE(max(1.0, 2.0) == 2.0);
         REQUIRE(max(1.0, 2.0, 3.0) == 3.0);
         REQUIRE(max(3.0, 2.0, 1.0) == 3.0);
-    }
-
-    SECTION("Booleans") {
-        REQUIRE(max(true) == true);
-        REQUIRE(max(true, false) == true);
-        REQUIRE(max(true, false, true) == true);
-        REQUIRE(max(false, true, false) == true);
     }
 }
 
 TEST_CASE("test_min") {
     SECTION("Integers") {
-        REQUIRE(min(1) == 1);
         REQUIRE(min(1, 2) == 1);
         REQUIRE(min(1, 2, 3) == 1);
         REQUIRE(min(3, 2, 1) == 1);
     }
 
     SECTION("Floating-point numbers") {
-        REQUIRE(min(1.0) == 1.0);
         REQUIRE(min(1.0, 2.0) == 1.0);
         REQUIRE(min(1.0, 2.0, 3.0) == 1.0);
         REQUIRE(min(3.0, 2.0, 1.0) == 1.0);
-    }
-
-    SECTION("Booleans") {
-        REQUIRE(min(true) == true);
-        REQUIRE(min(true, false) == false);
-        REQUIRE(min(true, false, true) == false);
-        REQUIRE(min(false, true, false) == false);
     }
 }
 


### PR DESCRIPTION
+ TaggedScalar as test and example.
+ Type customization mechanism with tests.
+ Readme description.
+ Divided test into different binaries.